### PR TITLE
🔧 Set webpack as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/geowarin/friendly-errors-webpack-plugin/issues"
   },
   "license": "MIT",
+  "peerDependencies": {
+    "webpack": "^2.0.0 || ^3.0.0"
+  },
   "devDependencies": {
     "babel-core": "^6.23.1",
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
Closes #55.
Related to https://github.com/zeit/next.js/issues/2339.